### PR TITLE
Update forallx-ubc-5-SLtrees.tex

### DIFF
--- a/Latex-Files/forallx-ubc-5-SLtrees.tex
+++ b/Latex-Files/forallx-ubc-5-SLtrees.tex
@@ -710,7 +710,7 @@ This tree gets us to the same result much more quickly, pointing to the same int
 \section{Choosing the right root}
 \label{sec.sl.treeroots}
 
-Trees are used to indicate whether the root is satisfiable. We test arguments for validity with a tree by putting their premises along with the negation of their conclusions in the root; if the tree remains open, indicating that the set is satisfiable, that means it's possible to satisfy the premises while falsifying the conclusion, which means the argument is invalid. If the tree closes, that suggests the argument is invalid.
+Trees are used to indicate whether the root is satisfiable. We test arguments for validity with a tree by putting their premises along with the negation of their conclusions in the root; if the tree remains open, indicating that the set is satisfiable, that means it's possible to satisfy the premises while falsifying the conclusion, which means the argument is invalid. If the tree closes, that suggests the argument is valid.
 
 But trees can be used to evaluate many other kinds of questions, aside from validity. Any question that can be converted into a question about satisfiability can be answered with a tree. For example, if you want to find out whether a set of sentences is consistent, put that set of sentences into the tree. A set of sentences is consistent if and only if there is an interpretation satisfying it, so you can use a tree to find out.
 


### PR DESCRIPTION
In the discussion on line 713 of checking the validity of an argument with a truth tree, the last sentence of the paragraph says.
> If the tree  closes, that suggests the argument is invalid.
It should say the opposite, that a closed tree proves the argument is valid.