### PR TITLE
Fix dead link to PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here are a few points of information about the book:
 Thank you to [Mavaddat Javid][4] for creating this repository.
 
 [1]: https://www.fecundity.com/logic/
-[2]: https://github.com/jonathanichikawa/for-all-x/blob/master/forallx-ubc.pdf
+[2]: https://github.com/jonathanichikawa/for-all-x/blob/master/forallx-ubc-1.2.1.pdf
 [3]: https://github.com/jonathanichikawa/for-all-x/issues
 [4]: https://github.com/mavaddat
 	


### PR DESCRIPTION
The link to the PDF of the textbook in the README is dead as it points to `forallx-ubc.pdf`. I fixed it, assuming the intent is that it points to a file with a version in its name, `forallx-ubc-1.2.1.pdf`.